### PR TITLE
Update licence key to SPDX 3.11 2020-11-25

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -4,7 +4,7 @@
         "type": "parserhook",
         "url": "https://www.mediawiki.org/wiki/Extension:PubmedParser",
         "version": "5.0.1",
-        "license-name": "GPL-2.0+",
+        "license-name": "GPL-2.0-or-later",
         "descriptionmsg": "pubmedparser-desc",
         "requires": {
                 "MediaWiki": ">= 1.28.0"


### PR DESCRIPTION
This change was introduced much earlier though. Refs: https://spdx.org/licenses/