### PR TITLE
Prevents article values from being overwritten, adds keywords param and strips abstract field

### DIFF
--- a/.github/workflows/mediawiki.yml
+++ b/.github/workflows/mediawiki.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
     strategy:
+      fail-fast: false
       matrix:
         include:
           - mw: 'REL1_35'

--- a/.github/workflows/mediawiki.yml
+++ b/.github/workflows/mediawiki.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/mediawiki.yml
+++ b/.github/workflows/mediawiki.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  test:
+    name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_35'
+            php: 7.4
+          - mw: 'REL1_36'
+            php: 7.4
+          - mw: 'REL1_37'
+            php: 7.4
+          - mw: 'master'
+            php: 7.4
+    runs-on: ubuntu-latest
+    steps:
+      # check out the repository
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test extension
+        uses: wikiteq/mediawiki-phpunit-action@v2
+        with:
+          php: ${{ matrix.php }}
+          mwbranch: ${{ matrix.mw }}
+          extension: PubmedParser
+          testgroup: extension-PubmedParser

--- a/.github/workflows/mediawiki.yml
+++ b/.github/workflows/mediawiki.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Test extension
         uses: wikiteq/mediawiki-phpunit-action@v2
         with:
+          type: extension
           php: ${{ matrix.php }}
           mwbranch: ${{ matrix.mw }}
           extension: PubmedParser

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-> **HEADS UP!**  
-> **THE MAIN BRANCH HAS BEEN RENAMED FROM "MASTER" TO "MAIN".**  
-> **TO UPDATE AN EXISTING LOCAL COPY OF THIS REPOSITORY:**  
-> **`git fetch`**  
+> **HEADS UP!**
+> **THE MAIN BRANCH HAS BEEN RENAMED FROM "MASTER" TO "MAIN".**
+> **TO UPDATE AN EXISTING LOCAL COPY OF THIS REPOSITORY:**
+> **`git fetch`**
 > **`git checkout -t origin/main`**
 
 ---
 
 # Extension PubmedParser
+
+[![CI](https://github.com/WikiTeq/PubmedParser/actions/workflows/mediawiki.yml/badge.svg)](https://github.com/WikiTeq/PubmedParser/actions/workflows/mediawiki.yml)
 
 <https://www.mediawiki.org/wiki/Extension:PubmedParser>
 

--- a/extension.json
+++ b/extension.json
@@ -43,5 +43,5 @@
       "description": "Use either 'file_get_contents' (default) or 'curl' to fetch article data."
     }
   },
-  "manifest_version": 1
+  "manifest_version": 2
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -27,5 +27,6 @@
 	"pubmedparser-etal": "''et al.''",
 	"pubmedparser-initialseparator": "",
 	"pubmedparser-initialperiod": "",
-	"pubmedparser-reload": "reload"
+	"pubmedparser-reload": "reload",
+	"pubmedparser-keywords": "keywords"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -27,5 +27,6 @@
 	"pubmedparser-etal": "Symbol or words to use in PubMed citation templates as 'et al.'.",
 	"pubmedparser-initialseparator": "Symbol to use in PubMed citations to separate authors' initials.",
 	"pubmedparser-initialperiod": "Symbol to place after authors' initials in PubMed citations.",
-	"pubmedparser-reload": "Parameter to use in PubmedParser parser function calls to force reloading the PubMed citation."
+	"pubmedparser-reload": "Parameter to use in PubmedParser parser function calls to force reloading the PubMed citation.",
+	"pubmedparser-keywords": "Name of the PubMed template variable to show keywords"
 }

--- a/includes/PubmedParser_Article.php
+++ b/includes/PubmedParser_Article.php
@@ -117,10 +117,13 @@ class Article
 						break;
 					case 'AbstractText':
 						$label = strip_tags( $reader->getAttribute( 'Label' ) );
+						$label = trim( preg_replace( '/\s\s+/', ' ', $label ) );
+						$content = strip_tags( $reader->readInnerXML() );
+						$content = trim( preg_replace( '/\s\s+/', ' ', $content ) );
 						if ( $label ) {
 							$label .= ': ';
 						}
-						$this->abstract .= $label . strip_tags( $reader->readInnerXML() ) . ' ';
+						$this->abstract .= $label . $content . ' ';
 						break;
 					case 'Keyword':
 						$this->keywords[] = $reader->readInnerXML();

--- a/includes/PubmedParser_Article.php
+++ b/includes/PubmedParser_Article.php
@@ -119,9 +119,7 @@ class Article
 						if ( $label ) {
 							$label .= ': ';
 						}
-						if ( !$this->abstract ) {
-							$this->abstract .= $label . $reader->readInnerXML() . ' ';
-						}
+						$this->abstract .= "\n\n" . $label . $reader->readInnerXML() . ' ';
 						break;
 				}
 			}

--- a/includes/PubmedParser_Article.php
+++ b/includes/PubmedParser_Article.php
@@ -1,24 +1,24 @@
 <?php
 /*
  *      Copyright 2011-2022 Daniel Kraus <bovender@bovender.de> and co-authors
- *      
+ *
  *      This program is free software; you can redistribute it and/or modify
  *      it under the terms of the GNU General Public License as published by
  *      the Free Software Foundation; either version 2 of the License, or
  *      (at your option) any later version.
- *      
+ *
  *      This program is distributed in the hope that it will be useful,
  *      but WITHOUT ANY WARRANTY; without even the implied warranty of
  *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *      GNU General Public License for more details.
- *      
+ *
  *      You should have received a copy of the GNU General Public License
  *      along with this program; if not, write to the Free Software
  *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  *      MA 02110-1301, USA.
  */
 namespace PubmedParser;
- 
+
 if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'This is an extension to MediaWiki and cannot be run standalone.' );
 }
@@ -70,32 +70,48 @@ class Article
 						$this->parseAuthors( $reader );
 						break;
 					case 'ArticleTitle':
-						$this->title = rtrim( $reader->readInnerXML(), '.' );
+						if ( !$this->title ) {
+							$this->title = rtrim( $reader->readInnerXML(), '.' );
+						}
 						break;
 					case 'Title':
-						$this->journal = $reader->readInnerXML();
+						if ( !$this->journal ) {
+							$this->journal = $reader->readInnerXML();
+						}
 						break;
 					case 'ISOAbbreviation':
-						$this->journalAbbrev = $reader->readInnerXML();
+						if ( !$this->journalAbbrev ) {
+							$this->journalAbbrev = $reader->readInnerXML();
+						}
 						break;
 					case 'MedlineTA':
-						$this->journalAbbrev = $reader->readInnerXML();
+						if ( !$this->journalAbbrev ) {
+							$this->journalAbbrev = $reader->readInnerXML();
+						}
 						break;
 					case 'PubDate':
 						$this->parseDate( $reader );
 						break;
 					case 'Volume':
-						$this->volume = $reader->readInnerXML();
+						if ( !$this->volume ) {
+							$this->volume = $reader->readInnerXML();
+						}
 						break;
 					case 'MedlinePgn':
-						$this->pages = $reader->readInnerXML();
+						if ( !$this->pages ) {
+							$this->pages = $reader->readInnerXML();
+						}
 						break;
 					case 'ArticleId':
 						if ( $reader->getAttribute( 'IdType' ) === 'pmc' ) {
-							$this->pmc = $reader->readInnerXML();
+							if ( !$this->pmc ) {
+								$this->pmc = $reader->readInnerXML();
+							}
 						}
 						if ( $reader->getAttribute( 'IdType' ) === 'doi' ) {
-							$this->doi = $reader->readInnerXML();
+							if ( !$this->doi ) {
+								$this->doi = $reader->readInnerXML();
+							}
 						}
 						break;
 					case 'AbstractText':
@@ -103,18 +119,20 @@ class Article
 						if ( $label ) {
 							$label .= ': ';
 						}
-						$this->abstract .= $label . $reader->readInnerXML(). ' ';
+						if ( !$this->abstract ) {
+							$this->abstract .= $label . $reader->readInnerXML() . ' ';
+						}
 						break;
 				}
 			}
 		}
 	}
 
-	/** Parse the authors node and build an array of last names and initials. 
+	/** Parse the authors node and build an array of last names and initials.
 	 * If a collective name is encountered, save it.
 	 */
 	protected function parseAuthors( \XMLReader $reader ) {
-		// Loop over the children of the AuthorList node and stop at the closing 
+		// Loop over the children of the AuthorList node and stop at the closing
 		// tag of the AuthorList node.
 		while ( $reader->read() && ! ( $reader->name === 'AuthorList' ) ) {
 			if ( $reader->nodeType == \XMLReader::ELEMENT ) {
@@ -132,9 +150,9 @@ class Article
 		}
 	}
 
-	/** Parses the publication date (PubmedArticleSet -> PubmedArticle -> 
+	/** Parses the publication date (PubmedArticleSet -> PubmedArticle ->
 	 * MedlineCitation -> Article -> Journal -> JournalIssue -> PubDate).
-	 * Sometimes, there will be no such node; in these cases, we use the 
+	 * Sometimes, there will be no such node; in these cases, we use the
 	 * 'MedlineDate' node that is a child of 'JournalIssue'.
 	 */
 	protected function parseDate( \XMLReader $reader) {
@@ -144,14 +162,14 @@ class Article
 					$this->year = $reader->readInnerXML();
 				}
 				elseif ( $reader->name === 'MedlineDate' && !$this->year ) {
-					// If we read the year of publication from the MedlineDate node, 
+					// If we read the year of publication from the MedlineDate node,
 					// we need to extract a four-digit string from this node's value.
 					if ( preg_match( '/\d{4}/', $reader->readInnerXML(), $matches ) ) {
 						$this->year = $matches[0];
 					}
 				}
 			}
-		}	
+		}
 	}
 
 	/** Returns an abbreviated list of the authors. If there are two
@@ -172,7 +190,7 @@ class Article
 		} else {
 			return $this->collectiveName;
 		}
-	} 
+	}
 
 	/** Returns a list of all authors of this article.
 	 *  @param $useInitials [in] Boolean; if True, initials will be appended
@@ -184,9 +202,9 @@ class Article
 			for ( $i=0; $i < $numAuthors-1; $i++ ) {
 				$a .= $this->authorName( $i, $useInitials ) . ', ';
 			}
-			// Cut off the last ", ", add the "and" character or word, and append 
+			// Cut off the last ", ", add the "and" character or word, and append
 			// the last author's name.
-			$a = substr( $a, 0, strlen( $a )-2 ) . ' ' . Extension::$and 
+			$a = substr( $a, 0, strlen( $a )-2 ) . ' ' . Extension::$and
 				. ' ' . $this->authorName( $i, $useInitials );
 		} elseif ( $numAuthors == 1 ) {
 			$a = $this->authorName( 0, $useInitials );
@@ -220,7 +238,7 @@ class Article
 	/** A private function that returns either the author's last name or
 	 * the "CollectiveName" is the author is a group.
 	 * \param $index Index of the author
-	 * \returns either the author's last name, or the group's collective name 
+	 * \returns either the author's last name, or the group's collective name
 	 */
 	private function authorName( $index, $useInitial = false ) {
 		if ( $index < count( $this->authors ) ) {
@@ -230,10 +248,10 @@ class Article
 				$iarray = str_split($i, 1);
 				$i = implode( Extension::$initialPeriod, $iarray)
 					. Extension::$initialPeriod;
-				// Spaces in the "Pubmedparser-initialperiod" system message must be 
-				// encoded as "&nbsp;", lest they be removed by MediaWiki's text 
-				// processing. In order to remove the trailing "&nbsp;" after 
-				// concatenating all authors and initials, we use the trim function 
+				// Spaces in the "Pubmedparser-initialperiod" system message must be
+				// encoded as "&nbsp;", lest they be removed by MediaWiki's text
+				// processing. In order to remove the trailing "&nbsp;" after
+				// concatenating all authors and initials, we use the trim function
 				// with " \xc2\xa0".
 				$author = trim( $author . Extension::$initialSeparator
 					. ' ' . $i, " \xc2\xa0");

--- a/includes/PubmedParser_Article.php
+++ b/includes/PubmedParser_Article.php
@@ -39,6 +39,7 @@ class Article
 	public $pmc;
 	public $xml;
 	public $message; ///< May hold an exception message.
+	public $keywords = [];
 
 	/** Constructs a new article object from a given Pubmed XML string.
 	 */
@@ -120,6 +121,9 @@ class Article
 							$label .= ': ';
 						}
 						$this->abstract .= $label . strip_tags( $reader->readInnerXML() ) . ' ';
+						break;
+					case 'Keyword':
+						$this->keywords[] = $reader->readInnerXML();
 						break;
 				}
 			}
@@ -231,6 +235,10 @@ class Article
 		}
 		$j = implode( ' ', $jwords );
 		return $j;
+	}
+
+	function allKeywords() {
+		return implode( ',', $this->keywords );
 	}
 
 	/** A private function that returns either the author's last name or

--- a/includes/PubmedParser_Article.php
+++ b/includes/PubmedParser_Article.php
@@ -115,11 +115,11 @@ class Article
 						}
 						break;
 					case 'AbstractText':
-						$label = $reader->getAttribute( 'Label' );
+						$label = strip_tags( $reader->getAttribute( 'Label' ) );
 						if ( $label ) {
 							$label .= ': ';
 						}
-						$this->abstract .= "\n\n" . $label . $reader->readInnerXML() . ' ';
+						$this->abstract .= $label . strip_tags( $reader->readInnerXML() ) . ' ';
 						break;
 				}
 			}

--- a/includes/PubmedParser_Core.php
+++ b/includes/PubmedParser_Core.php
@@ -132,6 +132,7 @@ class Core
 			. '|' . Extension::$pmc         . '=' . $article->pmc
 			. '|' . Extension::$abstract    . '=' . $article->abstract
 			. '|' . Extension::$title       . '=' . $article->title
+			. '|' . Extension::$keywords    . '=' . $article->allKeywords()
 			. '}}';
 	}
 

--- a/includes/PubmedParser_Extension.php
+++ b/includes/PubmedParser_Extension.php
@@ -103,6 +103,7 @@ class Extension {
 		self::$initialSeparator = wfMessage( 'pubmedparser-initialseparator' )->text();
 		self::$templateName     = wfMessage( 'pubmedparser-templatename' )->text();
 		self::$reload           = wfMessage( 'pubmedparser-reload' )->text();
+		self::$keywords         = wfMessage( 'pubmedparser-keywords' )->text();
 	}
 
 
@@ -128,6 +129,7 @@ class Extension {
 	public static $initialSeparator;
 	public static $templateName;
 	public static $reload;
+	public static $keywords;
 }
 
 // vim: ts=2:sw=2:noet:comments^=\:///

--- a/tests/phpunit/PubmedParser.Article.Test.php
+++ b/tests/phpunit/PubmedParser.Article.Test.php
@@ -7,19 +7,22 @@
  */
 namespace PubmedParser;
 
+/**
+ * @group extension-PubmedParser
+ */
 class ArticleTest extends \MediaWikiTestCase {
 
 	protected function setUp() {
-		parent:setUp();
+		parent::setUp();
 	}
 
 	/**
 	 * Main unit test for PubmedArticle properties.
-	 * This test contains lots of assertions which is not considered good 
-	 * style; however, placing the assertions in individual tests would have 
-	 * involved creating PubmedArticle objects with the same sample data over 
-	 * and over again. (I tried to use the '(at) depends' keyword of PHPUnit, 
-	 * but when an object was returned from the producer, NULL would be 
+	 * This test contains lots of assertions which is not considered good
+	 * style; however, placing the assertions in individual tests would have
+	 * involved creating PubmedArticle objects with the same sample data over
+	 * and over again. (I tried to use the '(at) depends' keyword of PHPUnit,
+	 * but when an object was returned from the producer, NULL would be
 	 * delivered to the consumer. Maybe there is a better way to do this.)
 	 * @dataProvider xmlProvider
 	 */
@@ -34,7 +37,7 @@ class ArticleTest extends \MediaWikiTestCase {
 	 		'Title incorrect' );
 		$this->assertEquals( $simpleArticle->Journal->Title, $article->journal,
 	 		'Journal name incorrect' );
-		$this->assertEquals( $simpleArticle->Journal->ISOAbbreviation, 
+		$this->assertEquals( $simpleArticle->Journal->ISOAbbreviation,
 			$article->journalAbbrev, 'Abbreviated journal name incorrect' );
 		$this->assertEquals( $simpleArticle->Pagination->MedlinePgn, $article->pages,
 	 		'Page numbers incorrect' );

--- a/tests/phpunit/PubmedParser.Article.Test.php
+++ b/tests/phpunit/PubmedParser.Article.Test.php
@@ -12,10 +12,6 @@ namespace PubmedParser;
  */
 class ArticleTest extends \MediaWikiTestCase {
 
-	protected function setUp() {
-		parent::setUp();
-	}
-
 	/**
 	 * Main unit test for PubmedArticle properties.
 	 * This test contains lots of assertions which is not considered good

--- a/tests/phpunit/PubmedParser.Core.Test.php
+++ b/tests/phpunit/PubmedParser.Core.Test.php
@@ -35,7 +35,7 @@ class CoreTest extends \MediaWikiTestCase {
 		'firstPage',
 	);
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 		// Since wfMessage returns empty strings, prepare the messages.
 		foreach ( $this->templateFields as $key => $value ) {

--- a/tests/phpunit/PubmedParser.Core.Test.php
+++ b/tests/phpunit/PubmedParser.Core.Test.php
@@ -5,12 +5,13 @@ namespace PubmedParser;
  * Unit tests for the PubmedParserFetcher class.
  * @group Database
  * @group bovender
+ * @group extension-PubmedParser
  */
 class CoreTest extends \MediaWikiTestCase {
 	private $testPmid = 454545;
 
-	/** An array of template fields that are used to build the reference. The 
-		* keys of this associative array map to the public static properties of 
+	/** An array of template fields that are used to build the reference. The
+		* keys of this associative array map to the public static properties of
 		* the PubmedParserFetcher class.
 	 */
 	private $templateFields = array(
@@ -46,9 +47,9 @@ class CoreTest extends \MediaWikiTestCase {
 			Extension::$$key = strtolower( $key );
 		};
 
-		// Manually set the template name; this cannot be done with the 
-		// $templateFields array since there is no corresponding value, and we 
-		// loop over the entire array further below to assert correctness of the 
+		// Manually set the template name; this cannot be done with the
+		// $templateFields array since there is no corresponding value, and we
+		// loop over the entire array further below to assert correctness of the
 		// template transclusion that was built.
 		Extension::$templateName = "pubmed";
 	}

--- a/tests/phpunit/PubmedParser.Core.Test.php
+++ b/tests/phpunit/PubmedParser.Core.Test.php
@@ -52,6 +52,11 @@ class CoreTest extends \MediaWikiTestCase {
 		// loop over the entire array further below to assert correctness of the
 		// template transclusion that was built.
 		Extension::$templateName = "pubmed";
+		
+		$this->tablesUsed = array_merge(
+			$this->tablesUsed,
+			[ 'pubmed' ]
+		);
 	}
 
 	/**


### PR DESCRIPTION
- Uses only first occurrence of specific tag to prevent values like `journal` from being overwritten by multiple occurrences of `Title` tag like for this article https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=32681566&retmode=xml where `Title` also present in `References` section
- Strips tags and newlines/whitespaces from Abstract field ( `AbstractText` )
- Makes `keywords` parameter available for the `Pubmed` template ( values are sources from  `Keyword` elements ), separated by comma
- Updates `extension.json` manifest version to `2`